### PR TITLE
TCK 3 Portlet.  Login field fails for the first time due to autofill

### DIFF
--- a/portlet-tck_3.0/driver/src/main/java/javax/portlet/tck/driver/TCKSimpleTestDriver.java
+++ b/portlet-tck_3.0/driver/src/main/java/javax/portlet/tck/driver/TCKSimpleTestDriver.java
@@ -403,7 +403,9 @@ public class TCKSimpleTestDriver {
          WebElement pwEl = pwels.get(0);
 
          // perform login
+         userEl.clear();
          userEl.sendKeys(username);
+         pwEl.clear();
          pwEl.sendKeys(password);
          pwEl.submit();
 

--- a/portlet-tck_3.0/pom.xml
+++ b/portlet-tck_3.0/pom.xml
@@ -106,7 +106,7 @@
 -->
 
       <test.server.username.id>_com_liferay_login_web_portlet_LoginPortlet_login</test.server.username.id>
-      <test.server.username>test</test.server.username>
+      <test.server.username>test@liferay.com</test.server.username>
       <test.server.password.id>_com_liferay_login_web_portlet_LoginPortlet_password</test.server.password.id>
       <test.server.password>test</test.server.password>
 


### PR DESCRIPTION
@vsingleton 

I think some of the selenium tests are failing because, when liferay first starts up the portal the login field already has the value of '@liferay.com'.

This is causing the first testcase of each group of tests to fail.

Instead we should put the full username (test@liferay.com) and clear the login field before filling in the username just to have a more consistent output.

Let me know if you have any questions.

Thanks!